### PR TITLE
[DEV] feat(migrations): add unique constraint for expense table

### DIFF
--- a/internal/migrations/000002_add_unique_index-for-expenses-table.sql
+++ b/internal/migrations/000002_add_unique_index-for-expenses-table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE expenses
+ADD CONSTRAINT unique_category_date_amount UNIQUE (category_id, action_date, amount);

--- a/internal/migrations/000002_remove_unique_index-for-expenses-table.sql
+++ b/internal/migrations/000002_remove_unique_index-for-expenses-table.sql
@@ -1,0 +1,2 @@
+ALTER TABLE expenses
+DROP CONSTRAINT unique_category_date_amount;


### PR DESCRIPTION
I added a unique composite constraint to prevent saving random duplicates when uploading a large list of expenses. An expense is considered a duplicate if a transaction for the same amount on the same day for the same category has already been made. This is a very unlikely event, but it will help eliminate duplicates.